### PR TITLE
[Lazy Loading]

### DIFF
--- a/03-desenvolvimento-back-end/bloco-24-nodejs-orm-e-autenticacao/dia-02-orm-associations-1-1-e-1-n/pratica/src/controllers/employee.controller.js
+++ b/03-desenvolvimento-back-end/bloco-24-nodejs-orm-e-autenticacao/dia-02-orm-associations-1-1-e-1-n/pratica/src/controllers/employee.controller.js
@@ -1,4 +1,6 @@
 const EmployeeService = require('../services/employee.service');
+const AddressService = require('../services/address.service');
+
 
 const getAll = async (_req, res) => {
   try {
@@ -17,6 +19,11 @@ const getById = async (req, res) => {
 
     if (!employee) {
       return res.status(404).json({ message: 'Pessoa colaboradora não encontrada' });
+    }
+    if (req.query.includeAddresses === 'true') {
+      const addresses = await AddressService.getAllByEmployeeId(id);
+
+      return res.status(200).json({ employee, addresses });
     }
     return res.status(200).json(employee);
   } catch (e) {

--- a/03-desenvolvimento-back-end/bloco-24-nodejs-orm-e-autenticacao/dia-02-orm-associations-1-1-e-1-n/pratica/src/services/address.service.js
+++ b/03-desenvolvimento-back-end/bloco-24-nodejs-orm-e-autenticacao/dia-02-orm-associations-1-1-e-1-n/pratica/src/services/address.service.js
@@ -1,0 +1,11 @@
+const { Address } = require('../models/');
+
+const getAllByEmployeeId = async (employeeId) => {
+  const addresses = await Address.findAll({ where: { employeeId } });
+
+  return addresses;
+};
+
+module.exports = {
+  getAllByEmployeeId,
+};

--- a/03-desenvolvimento-back-end/bloco-24-nodejs-orm-e-autenticacao/dia-02-orm-associations-1-1-e-1-n/pratica/src/services/employee.service.js
+++ b/03-desenvolvimento-back-end/bloco-24-nodejs-orm-e-autenticacao/dia-02-orm-associations-1-1-e-1-n/pratica/src/services/employee.service.js
@@ -11,13 +11,10 @@ const getAll = async () => {
 
 
 const getById = async (id) => {
-    const employee = await Employee.findOne({
-        where: { id },
-        include: [{
-            model: Address, as: 'addresses', attributes: { exclude: ['number'] },   
-          }],
-    });
-    return employee;
-}
+    const employee = await Employee.findOne({  
+      where: { id },  
+    });  
+    return employee;  
+  }
 
 module.exports = { getAll, getById };


### PR DESCRIPTION
Esse método consiste, basicamente, em não especificar uma propriedade includes no momento de realizar a query no banco. Dessa forma, cria-se a possibilidade de termos dois usos para o mesmo endpoint.